### PR TITLE
Set the content type when posting to the tracker.

### DIFF
--- a/GameMod/ServerStatLog.cs
+++ b/GameMod/ServerStatLog.cs
@@ -148,6 +148,7 @@ namespace GameMod
                 downloadHandler = new DownloadHandlerBuffer(),
                 method = UnityWebRequest.kHttpVerbPOST
             };
+            request.SetRequestHeader("Content-Type", "application/json");
             GameManager.m_gm.StartCoroutine(RequestCoroutine(request.SendWebRequest()));
         }
 


### PR DESCRIPTION
Fixes a bug with the data being sent to the tracker improperly, resulting in an empty object on the tracker.