### PR TITLE
Observer mode fixes.

### DIFF
--- a/GameMod/MPObserver.cs
+++ b/GameMod/MPObserver.cs
@@ -64,6 +64,7 @@ namespace GameMod
                 GameManager.m_local_player.Networkm_spectator = true;
                 GameManager.m_player_ship.c_player.m_spectator = true;
                 GameManager.m_local_player.m_spectator = true;
+                GameManager.m_player_ship.c_camera.useOcclusionCulling = false;
             }
             else
             {
@@ -103,6 +104,7 @@ namespace GameMod
     {
         static void Prefix()
         {
+            GameManager.m_player_ship.c_camera.useOcclusionCulling = true;
             GameplayManager.m_use_segment_visibility = true;
             MPObserver.Enabled = false;
         }
@@ -125,7 +127,17 @@ namespace GameMod
     {
         static bool Prefix()
         {
-            return !GameManager.m_local_player.m_spectator;
+            if (GameManager.m_local_player.m_spectator)
+            {
+                if (GameplayManager.IsMultiplayer)
+                {
+                    ChunkManager.ForceActivateAll();
+                    ChunkManager.DisableReflectionProbes();
+                    ChunkManager.DisableLights();
+                    return false;
+                }
+            }
+            return true;
         }
     }
 
@@ -195,6 +207,7 @@ namespace GameMod
                         continue;
                     Debug.LogFormat("Enabling spectator for {0}", player.m_mp_name);
                     player.Networkm_spectator = true;
+                    GameManager.m_player_ship.c_camera.useOcclusionCulling = false;
                     Debug.LogFormat("Enabled spectator for {0}", player.m_mp_name);
                 }
         }


### PR DESCRIPTION
Fix/disable chunking in multiplayer observer mode.
Don't use occlusion culling as observer.

Two outstanding requests that I could not figure out how to pull off:

1) Always show player names.  I tried this code, but it failed.

```
    // Always show enemy names.
    [HarmonyPatch(typeof(NetworkMatch), "StartPlaying")]
    class MPObserverPlayerNamesAlways
    {
        static void Prefix()
        {
            if (GameManager.m_local_player.m_spectator)
            {
                NetworkMatch.m_show_enemy_names = MatchShowEnemyNames.ALWAYS;
            }
        }
    }
```

2) Disable skybox for observer.  A skybox exists in some maps, and causes all kinds of flickering.  As an example, Vault has a pitch black skybox, and Foundry has a star field for a skybox.  If we could disable the skyboxes entirely in those maps, that would fix the bugs with them.  Since this is not actually called `skybox` in Revival's code, I can't find it.