### PR TITLE
Fix matchMode in StartGame stat.

### DIFF
--- a/GameMod/ServerStatLog.cs
+++ b/GameMod/ServerStatLog.cs
@@ -470,6 +470,18 @@ namespace GameMod
             }
         }
 
+        public static string GetMatchModeString(MatchMode mode)
+        {
+            switch (mode)
+            {
+                case MatchMode.ANARCHY: return "ANARCHY";
+                case MatchMode.TEAM_ANARCHY: return "TEAM_ANARCHY";
+                case MatchMode.MONSTERBALL: return "MONSTERBALL";
+                case CTF.MatchModeCTF: return "CTF";
+                default: return "UNKNOWN";
+            }
+        }
+
         public static string GetLevel(int levelNum, string level)
         {
             if (string.IsNullOrEmpty(level))
@@ -508,7 +520,7 @@ namespace GameMod
                 turnSpeedLimit = GetTurnSpeedLimitString(NetworkMatch.m_turn_speed_limit),
                 powerupSpawn = GetPowerupSpawnString(NetworkMatch.m_powerup_spawn),
                 friendlyFire = NetworkMatch.m_team_damage,
-                matchMode = NetworkMatch.GetMode().ToString()?.Replace("_", " "),
+                matchMode = GetMatchModeString(NetworkMatch.GetMode()),
                 maxPlayers = NetworkMatch.GetMaxPlayersForMatch(),
                 showEnemyNames = NetworkMatch.m_show_enemy_names.ToString()?.Replace("_", " "),
                 timeLimit = NetworkMatch.m_match_time_limit_seconds,


### PR DESCRIPTION
Because the game mode is an uneditable enum and CTF is not in the enum, the matchMode was returning "NUM" for CTF games.  This fixes that issue by creating a custom MatchMode to string function, which will need to be expanded for future game modes.