### PR TITLE
Option for sudden death overtime in MB & CTF

### DIFF
--- a/GameMod/CTF.cs
+++ b/GameMod/CTF.cs
@@ -768,13 +768,14 @@ namespace GameMod
 
         static void Postfix()
         {
-            if (Client.GetClient() == null)
-                return;
-            Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFPickup, OnCTFPickup);
-            Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFLose, OnCTFLose);
-            Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFNotifyOld, OnCTFNotifyOld);
-            Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFFlagUpdate, OnCTFFlagUpdate);
-            Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFNotify, OnCTFNotify);
+            if (Client.GetClient() != null)
+            {
+                Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFPickup, OnCTFPickup);
+                Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFLose, OnCTFLose);
+                Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFNotifyOld, OnCTFNotifyOld);
+                Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFFlagUpdate, OnCTFFlagUpdate);
+                Client.GetClient().RegisterHandler(CTFCustomMsg.MsgCTFNotify, OnCTFNotify);
+            }
         }
     }
 

--- a/GameMod/GameMod.csproj
+++ b/GameMod/GameMod.csproj
@@ -109,6 +109,7 @@
     <Compile Include="MPLongPwd.cs" />
     <Compile Include="MPMatchPresets.cs" />
     <Compile Include="MPPickupCheck.cs" />
+    <Compile Include="MPSuddenDeath.cs" />
     <Compile Include="MPSuperCheck.cs" />
     <Compile Include="MPTriggers.cs" />
     <Compile Include="MPDownloadLevel.cs" />

--- a/GameMod/MPMatchPresets.cs
+++ b/GameMod/MPMatchPresets.cs
@@ -51,7 +51,8 @@ namespace GameMod
                 powerupInitial = MenuManager.mms_powerup_initial,
                 powerupBigSpawn = MenuManager.mms_powerup_big_spawn,
                 powerupFilter = MenuManager.mms_powerup_filter,
-                jipEnabled = ModPrefs.GetBool("MP_PM_JIP", true)
+                jipEnabled = ModPrefs.GetBool("MP_PM_JIP", true),
+                suddenDeathOvertime = false
             });
 
             presets.Add(new MPMatchPreset
@@ -77,11 +78,12 @@ namespace GameMod
                 powerupInitial = 2,
                 powerupBigSpawn = 1,
                 powerupFilter = new bool[] { true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true },
-                jipEnabled = true
+                jipEnabled = true,
+                suddenDeathOvertime = false
             });
 
             GameManager.m_gm.StartCoroutine(GetMatchPresets());
-        }        
+        }
 
         class MPMatchPreset
         {
@@ -107,7 +109,8 @@ namespace GameMod
             public int powerupBigSpawn;
             public bool[] powerupFilter;
             public bool jipEnabled;
-            
+            public bool suddenDeathOvertime;
+
             public void Apply()
             {
                 MenuManager.mms_mode = this.matchMode;
@@ -131,6 +134,7 @@ namespace GameMod
                 MenuManager.mms_powerup_big_spawn = this.powerupBigSpawn;
                 MenuManager.mms_powerup_filter = this.powerupFilter;
                 MPJoinInProgress.MenuManagerEnabled = this.jipEnabled;
+                MPSuddenDeath.SuddenDeathEnabled = this.suddenDeathOvertime;
             }
         }
 
@@ -145,7 +149,7 @@ namespace GameMod
                 {
                     urls.Add(jUrl.Value<string>());
                 }
-            }            
+            }
 
             foreach (var url in urls)
             {
@@ -166,7 +170,7 @@ namespace GameMod
                 }
             }
         }
-        
+
         [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
         class MPMatchPresetDrawMpMatchSetup
         {

--- a/GameMod/MPSetup.cs
+++ b/GameMod/MPSetup.cs
@@ -19,6 +19,7 @@ namespace GameMod
             MPTeams.NetworkMatchTeamCount = 2;
             MPJoinInProgress.NetworkMatchEnabled = false;
             RearView.MPNetworkMatchEnabled = false;
+            MPSuddenDeath.SuddenDeathEnabled = false;
         }
     }
 
@@ -38,6 +39,7 @@ namespace GameMod
                 MPTeams.NetworkMatchTeamCount = (NetworkMatch.m_name[i + 1] & 7) + 2;
                 MPJoinInProgress.NetworkMatchEnabled = (NetworkMatch.m_name[i + 1] & 8) != 0;
                 RearView.MPNetworkMatchEnabled = (NetworkMatch.m_name[i + 1] & 16) != 0;
+                MPSuddenDeath.SuddenDeathEnabled = (NetworkMatch.m_name[i + 1] & 32) != 0;
             }
         }
 
@@ -73,7 +75,8 @@ namespace GameMod
                 __result.m_name += new string(new char[] { '\0', (char)(
                     ((Math.Max(2, MPTeams.MenuManagerTeamCount) - 2) & 7) |
                     (MPJoinInProgress.MenuManagerEnabled || MPJoinInProgress.SingleMatchEnable ? 8 : 0) |
-                    (RearView.MPMenuManagerEnabled ? 16 : 0))});
+                    (RearView.MPMenuManagerEnabled ? 16 : 0) |
+                    (MPSuddenDeath.SuddenDeathEnabled ? 32 : 0))});
             }
             Debug.Log("Build PMD name " + String.Join(",", __result.m_name.Select(x => ((int)x).ToString()).ToArray()));
             if (MPJoinInProgress.MenuManagerEnabled || MPJoinInProgress.SingleMatchEnable)
@@ -89,6 +92,7 @@ namespace GameMod
             MPTeams.MenuManagerTeamCount = 2;
             MPJoinInProgress.MenuManagerEnabled = false;
             RearView.MPMenuManagerEnabled = false;
+            MPSuddenDeath.SuddenDeathEnabled = false;
         }
     }
 

--- a/GameMod/MPSuddenDeath.cs
+++ b/GameMod/MPSuddenDeath.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using Harmony;
+using Overload;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace GameMod
+{
+    class MPSuddenDeath
+    {
+        public static bool SuddenDeathEnabled = true; // TODO: Make this an option.
+        public static bool InOvertime = false;
+
+        public static int GetTimer()
+        {
+            if (NetworkMatch.m_match_time_limit_seconds == int.MaxValue || !SuddenDeathEnabled)
+            {
+                return NetworkMatch.m_match_time_remaining;
+            }
+
+            return Math.Abs(NetworkMatch.m_match_time_limit_seconds - (int)NetworkMatch.m_match_elapsed_seconds);
+        }
+    }
+
+    public class SuddenDeathCustomMsg
+    {
+        public const short MsgSuddenDeath = 126;
+    }
+
+    public class SuddenDeathMessage : MessageBase
+    {
+        public override void Serialize(NetworkWriter writer)
+        {
+            writer.Write(m_message);
+        }
+        public override void Deserialize(NetworkReader reader)
+        {
+            m_message = reader.ReadString();
+        }
+
+        public string m_message;
+    }
+
+    [HarmonyPatch(typeof(NetworkMatch), "InitBeforeEachMatch")]
+    class SuddenDeathInitBeforeEachMatch
+    {
+        private static void Postfix()
+        {
+            MPSuddenDeath.InOvertime = false;
+        }
+    }
+    
+    [HarmonyPatch(typeof(NetworkMatch), "MaybeEndTimer")]
+    class MaybeEndTimer
+    {
+        public static bool Prefix()
+        {
+            if (
+                NetworkMatch.m_match_elapsed_seconds > NetworkMatch.m_match_time_limit_seconds
+                && (NetworkMatch.GetMode() == MatchMode.MONSTERBALL || NetworkMatch.GetMode() == CTF.MatchModeCTF)
+                && MPSuddenDeath.SuddenDeathEnabled
+                && NetworkMatch.m_team_scores[(int)MpTeam.TEAM0] == NetworkMatch.m_team_scores[(int)MpTeam.TEAM1]
+            )
+            {
+                if (!MPSuddenDeath.InOvertime)
+                {
+                    Debug.Log("Sudden Death!");
+                    MPSuddenDeath.InOvertime = true;
+                    NetworkServer.SendToAll(SuddenDeathCustomMsg.MsgSuddenDeath, new SuddenDeathMessage
+                    {
+                        m_message = "Sudden Death!"
+                    });
+
+                }
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Client), "RegisterHandlers")]
+    class SuddenDeathClientHandlers
+    {
+        private static void OnSuddenDeathNotify(NetworkMessage rawMsg)
+        {
+            var msg = rawMsg.ReadMessage<SuddenDeathMessage>();
+
+            if (msg.m_message != null)
+                GameplayManager.AddHUDMessage(msg.m_message, -1, true);
+        }
+
+        static void Postfix()
+        {
+            if (Client.GetClient() != null)
+            {
+                Client.GetClient().RegisterHandler(SuddenDeathCustomMsg.MsgSuddenDeath, OnSuddenDeathNotify);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UIElement), "DrawHUDScoreInfo")]
+    class DrawHUDScoreInfo
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            bool found = false;
+            foreach (var code in instructions)
+            {
+                if (!found && code.opcode == OpCodes.Ldloc_S && ((LocalBuilder)code.operand).LocalIndex == 5)
+                {
+                    found = true;
+
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPSuddenDeath), "GetTimer"));
+
+                    continue;
+                }
+
+                yield return code;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UIElement), "DrawMpMiniScoreboard")]
+    class DrawMpMiniScoreboard
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            bool found = false;
+            foreach (var code in instructions)
+            {
+                if (!found && code.opcode == OpCodes.Ldloc_1)
+                {
+                    found = true;
+
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPSuddenDeath), "GetTimer"));
+
+                    continue;
+                }
+
+                yield return code;
+            }
+        }
+    }
+}

--- a/GameMod/MPSuddenDeath.cs
+++ b/GameMod/MPSuddenDeath.cs
@@ -12,7 +12,7 @@ namespace GameMod
 {
     class MPSuddenDeath
     {
-        public static bool SuddenDeathEnabled = true; // TODO: Make this an option.
+        public static bool SuddenDeathEnabled = false; // TODO: Make this an option.
         public static bool InOvertime = false;
 
         public static int GetTimer()
@@ -143,6 +143,55 @@ namespace GameMod
                 }
 
                 yield return code;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UIElement), "DrawMpMatchSetup")]
+    class MPSuddenDeath_DrawMpMatchSetup
+    {
+        private static string GetMMSSuddenDeath()
+        {
+            return MenuManager.GetToggleSetting(Convert.ToInt32(MPSuddenDeath.SuddenDeathEnabled));
+        }
+
+        private static void DrawSuddenDeathToggle(UIElement uie, ref Vector2 position)
+        {
+            uie.SelectAndDrawStringOptionItem(Loc.LS("SUDDEN DEATH OVERTIME"), position, 10, GetMMSSuddenDeath(), string.Empty, 1.5f, MenuManager.mms_mode != MatchMode.NUM);
+            position.y += 62f;
+        }
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> codes)
+        {
+            var powerupFound = false;
+            foreach (var code in codes)
+            {
+                if (!powerupFound && code.opcode == OpCodes.Ldstr && (string)code.operand == "POWERUP SETTINGS")
+                {
+                    powerupFound = true;
+                    yield return new CodeInstruction(OpCodes.Ldloca, 0);
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MPSuddenDeath_DrawMpMatchSetup), "DrawSuddenDeathToggle"));
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                }
+
+                yield return code;
+            }
+        }
+    }
+
+    // Process slider input
+    [HarmonyPatch(typeof(MenuManager), "MpMatchSetup")]
+    class MPSuddenDeath_MpMatchSetup
+    {
+        static void Postfix()
+        {
+            if (MenuManager.m_menu_sub_state == MenuSubState.ACTIVE &&
+                (UIManager.PushedSelect(100) || UIManager.PushedDir()) &&
+                MenuManager.m_menu_micro_state == 3 &&
+                UIManager.m_menu_selection == 10)
+            {
+                MPSuddenDeath.SuddenDeathEnabled = !MPSuddenDeath.SuddenDeathEnabled;
+                MenuManager.PlayCycleSound(1f, (float)UIManager.m_select_dir);
             }
         }
     }


### PR DESCRIPTION
This causes ties in Monsterball and CTF to not end the game on time expiration if the score is tied.  The game will end on the next goal.

The OTL will need this implemented before March 30.