### PR TITLE
Observer mode enhancements

### DIFF
--- a/GameMod/MPObserver.cs
+++ b/GameMod/MPObserver.cs
@@ -610,6 +610,18 @@ namespace GameMod
     [HarmonyPatch(typeof(Controls), "UpdateKey")]
     class MPObserverControlsUpdateKey
     {
+        static bool Prefix(CCInput cc_type)
+        {
+            if (MPObserver.Enabled && GameplayManager.IsMultiplayer)
+            {
+                if (cc_type == CCInput.FIRE_FLARE)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         static void Postfix(CCInput cc_type)
         {
             if (MPObserver.Enabled && GameplayManager.IsMultiplayer)


### PR DESCRIPTION
Introduce 1st/3rd person mode observing, including various effects in first person mode.  Also disable flares in observer mode.

The following keys will perform special observer mode-only commands.
* Next/Prev primary - Cycle through available pilots to observe.
* Next/Prev secondary - View the orange/blue flag carrier (CTF Only)
* Fire primary - Freely observe.
* Fire secondary - Toggle 1st/3rd person mode.