### PR TITLE
Fix observer mode first person after observed ship dies.

### DIFF
--- a/GameMod/MPObserver.cs
+++ b/GameMod/MPObserver.cs
@@ -303,6 +303,8 @@ namespace GameMod
                     {
                         __instance.c_transform.position -= __instance.c_transform.rotation * new Vector3(0, -0.5f, 2f);
                     }
+
+                    MPObserver.SetPlayerVisibility(player, MPObserver.ThirdPerson);
                 }
             }
         }


### PR DESCRIPTION
A statement was removed that needs to be in there to fix the visibility of ships after they respawn.  This PR puts that statement back.